### PR TITLE
[#1281] Run "build" automatically before "pretest:single"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ before_install:
 before_script:
   - npm prune
 script:
-  - npm run build
   - npm run test:single
   - npm run check-coverage
 after_success:

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "report-coverage": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "start": "npm run test",
     "test": "mocha src/index.test.js -w --watch-extensions json --compilers js:babel/register",
+    "pretest:single": "npm run build",
     "test:single": "cp src/index.test.js dist/ && istanbul cover -x *.test.js _mocha -- -R spec dist/index.test.js --compilers js:babel/register && rm dist/index.test.js",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },


### PR DESCRIPTION
As "pretest:single" requires "build" to have been run, we make this dependency
explicit in the code.

Fixes openspending/openspending#1281